### PR TITLE
bug: Fix build in linux using `gcc-arm-none-eabi`

### DIFF
--- a/2.Firmware/Core-STM32F4-fw/3rdParty/fibre/cpp/include/fibre/protocol.hpp
+++ b/2.Firmware/Core-STM32F4-fw/3rdParty/fibre/cpp/include/fibre/protocol.hpp
@@ -8,6 +8,8 @@ see protocol.md for the protocol specification
 // TODO: resolve assert
 #define assert(expr)
 
+#include <cstdio>
+
 #include <functional>
 #include <limits>
 #include <cmath>

--- a/2.Firmware/Core-STM32F4-fw/3rdParty/fibre/cpp/protocol.cpp
+++ b/2.Firmware/Core-STM32F4-fw/3rdParty/fibre/cpp/protocol.cpp
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <stdlib.h>
+#include <cstdio>
 
 #include <fibre/protocol.hpp>
 #include <fibre/crc.hpp>

--- a/2.Firmware/Core-STM32F4-fw/3rdParty/fibre/cpp/protocol.cpp
+++ b/2.Firmware/Core-STM32F4-fw/3rdParty/fibre/cpp/protocol.cpp
@@ -3,7 +3,6 @@
 
 #include <memory>
 #include <stdlib.h>
-#include <cstdio>
 
 #include <fibre/protocol.hpp>
 #include <fibre/crc.hpp>

--- a/2.Firmware/Core-STM32F4-fw/Bsp/imu/MPU6050.cpp
+++ b/2.Firmware/Core-STM32F4-fw/Bsp/imu/MPU6050.cpp
@@ -34,7 +34,7 @@ THE SOFTWARE.
 ===============================================
 */
 
-#include "mpu6050.hpp"
+#include "MPU6050.hpp"
 
 #define pgm_read_byte(addr)   (*(const unsigned char *)(addr))
 

--- a/2.Firmware/Core-STM32F4-fw/Robot/instances/dummy_robot.h
+++ b/2.Firmware/Core-STM32F4-fw/Robot/instances/dummy_robot.h
@@ -1,6 +1,8 @@
 #ifndef REF_STM32F4_FW_DUMMY_ROBOT_H
 #define REF_STM32F4_FW_DUMMY_ROBOT_H
 
+#include <string>
+
 #include "algorithms/kinematic/6dof_kinematic.h"
 #include "actuators/ctrl_step/ctrl_step.hpp"
 


### PR DESCRIPTION
### intro

This is a bug fix when build the `2.Firmware/Core-STM32F4-fw` in linux using `gcc-arm-none-eabi`.

### build log

``` shell
Dummy-Robot/2.Firmware/Core-STM32F4-fw/3rdParty/fibre/cpp/protocol.cpp:9:1: note: 'snprintf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?

Dummy-Robot/2.Firmware/Core-STM32F4-fw/Robot/instances/dummy_robot.h:5:1: note: 'std::string' is defined in header '<string>'; did you forget to '#include <string>'?

Dummy-Robot/2.Firmware/Core-STM32F4-fw/Bsp/imu/MPU6050.cpp:37:10: fatal error: mpu6050.hpp: No such file or directory
   37 | #include "mpu6050.hpp"
```

### code change 

include `<cstdio>` in `protocol.hpp`
include `<string>` in `dummy_robot.h`
change `#include "mpu6050.hpp"` to `include "MPU6050.hpp"` in MPU6050.cpp

-Neko.vecter
